### PR TITLE
frontend: dark color-scheme basic implementation 🌚

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>request catcher</title>
+    <meta content="dark light" name="color-scheme">
     <link href="https://fonts.googleapis.com/css?family=Ubuntu+Mono|Source+Code+Pro|Cousine|Open+Sans:400,300,600" rel="stylesheet" type='text/css'>
     <link rel="stylesheet" href="/static/index.css?v=0.2" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>

--- a/frontend/root.html
+++ b/frontend/root.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <title>Request Catcher — record HTTP requests, webhooks, API calls</title>
+    <meta content="dark light" name="color-scheme">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/global.css" />

--- a/frontend/static/global.css
+++ b/frontend/static/global.css
@@ -2,7 +2,6 @@ html, body {
   margin: 0;
   padding: 0;
   font-family: 'Open Sans', sans-serif;
-  background: #FFF;
 }
 
 a {
@@ -20,7 +19,7 @@ a:hover {
   padding: 10px;
 }
 
-h1 { color: #222; }
+h1 { opacity: .87 }
 
 #root {
   display: flex;
@@ -43,7 +42,6 @@ h1 { color: #222; }
   width: 5em;
   text-align: center;
   font-weight: lighter;
-  background: #FFF;
   border: 1px #DDD solid;
   border-radius: 5px;
 }
@@ -77,7 +75,6 @@ h2 {
 
 #explanation {
   margin: 50px 0 20px 0;
-  color: #333;
   flex: 1;
 }
 

--- a/frontend/static/index.css
+++ b/frontend/static/index.css
@@ -17,7 +17,6 @@ body, pre {
 }
 
 h1 {
-  color: #000;
   font-family: "Open Sans";
   padding: 0.75em 1em;
   font-size: 2em;
@@ -58,7 +57,6 @@ div#no-requests .code {
 }
 
 h2 {
-  color: #000;
   font-family: "Open Sans";
   margin: 0;
   font-size: 1.5em;
@@ -73,15 +71,14 @@ h2 {
     min-width: 300px;
 }
 #selector .selected {
-    background: #eff9eb;
+  background: rgba(74, 250, 3, 0.06);
 }
 .snippet .timestamp, .snippet .remoteaddr {
   font-size: 0.8em;
-  color: #333;
+  opacity: .8;
 }
 
 #referral {
-  color: #000;
   text-align: center;
   font-family: "Open Sans";
   padding: 0.75em 1em;
@@ -89,7 +86,8 @@ h2 {
   margin: 2em 0;
 }
 #referral a {
-  color: #111;
+  color: inherit;
+  opacity: .9;
   text-decoration: none;
 }
 #referral a:hover strong  {


### PR DESCRIPTION
Native browser **color-scheme** implementation based on `<meta content="dark light" name="color-scheme">` tag and initial **font**/**background** colors